### PR TITLE
Builder connect signals

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/application-lifecycle.html
+++ b/docs/application-lifecycle.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/build-tags.html
+++ b/docs/build-tags.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/builder-connect-signals.html
+++ b/docs/builder-connect-signals.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+        <title>Connecting Builder signals - gobbi</title>
+
+        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="idea.css">
+
+        <script src="highlight.pack.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
+    </head>
+
+    <body>
+        <header>
+    <a class="home" href="/gobbi/">gobbi</a>
+
+    <a href="https://github.com/pekim/gobbi" rel="noopener">
+        <img src="github.svg">
+        github repo
+    </a>
+</header>
+
+
+        <div class="body">
+            <nav>
+    <ol>
+            <li>
+                <a href="index.html">Introduction</a>
+            </li>
+            <li>
+                <a href="getting-started.html">Getting started</a>
+            </li>
+            <li>
+                <a href="application-lifecycle.html">Application lifecycle</a>
+            </li>
+            <li>
+                <a href="build-tags.html">Build tags</a>
+            </li>
+            <li>
+                <a href="goroutines.html">Goroutines</a>
+            </li>
+            <li>
+                <a href="casting.html">Casting</a>
+            </li>
+            <li>
+                <a href="signal-handling.html">Signal handling</a>
+            </li>
+            <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
+                <a href="variadic-functions.html">Variadic functions</a>
+            </li>
+            <li>
+                <a href="gvalue.html">gobject.Value</a>
+            </li>
+            <li>
+                <a href="reference-counting.html">Reference counting</a>
+            </li>
+            <li>
+                <a href="subclassing.html">Subclassing</a>
+            </li>
+            <li>
+                <a href="api.html">API docs</a>
+            </li>
+    </ol>
+</nav>
+
+
+            <div class="content">
+                <h1>Connecting Builder signals</h1>
+                <h2>signals in UI definitions</h2>
+
+<p>User interfaces may be defined by in XML documents.
+Such documents are typically edited with Glade.</p>
+
+<p>Signals, along with a named handler, maybe appear in a definition.</p>
+
+<pre><code class="language-xml">&lt;interface&gt;
+  ...
+    &lt;object class=&quot;GtkButton&quot; id=&quot;ok_button&quot;&gt;
+      &lt;signal name=&quot;clicked&quot; handler=&quot;ok_button_clicked&quot;/&gt;
+    &lt;/object&gt;
+  ...
+&lt;/interface&gt;
+</code></pre>
+
+<p>The <code>handler</code> attribute value provides a name
+that can be used to associate the signal with a handler function.</p>
+
+<h2>connecting</h2>
+
+<p>To connect signals from a UI definition,
+call <code>Builder</code>&rsquo;s <code>ConnectSignals</code> method.
+The single argument is a map of handler names to handler functions</p>
+
+<p>The map keys should match <code>handler</code> attribute values in
+the UI definition.</p>
+
+<p>The handler function signatures must match the signal&rsquo;s
+equivalent <code>Connect...</code> function.</p>
+
+<h2>example</h2>
+
+<pre><code class="language-go">builder := gtk.BuilderNewFromString(`
+    &lt;interface&gt;
+      &lt;object class=&quot;GtkButton&quot; id=&quot;ok_button&quot;&gt;
+        &lt;signal name=&quot;clicked&quot; handler=&quot;ok_button_clicked&quot;/&gt;
+        &lt;signal name=&quot;draw&quot; handler=&quot;draw&quot;/&gt;
+      &lt;/object&gt;
+    &lt;/interface&gt;
+`)
+
+err := builder.ConnectSignals(map[string]interface{}{
+    &quot;ok_button_clicked&quot;: func(button *gtk.Button) {
+        // handle the click
+    },
+    &quot;draw&quot;: func(widget *gtk.Widget, cr *cairo.Context) bool {
+        // draw something in the context
+        return false
+    },
+})
+</code></pre>
+
+<p>See the tests in
+<a href="https://github.com/pekim/gobbi/blob/master/internal/test/gtk/gtkbuilder-connect-signals_test.go">gtkbuilder-connect-signals_test.go</a>
+for more examples
+including some error scenarios.</p>
+
+<h2>errors</h2>
+
+<p>There are a number of errors that may occur while connecting signals.
+* A key in the map passed to <code>ConnectSignals</code> may not match any
+<code>handler</code> attribute value in the UI definition.
+* A handler function&rsquo;s signature may be incorrect.
+* A signal name may be valid, but the signal may not be supported by gobbi.</p>
+
+<p>Any of these will result in an <code>error</code> being returned.</p>
+
+            </div>
+        </div>
+    </body>
+</html>

--- a/docs/casting.html
+++ b/docs/casting.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/goroutines.html
+++ b/docs/goroutines.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/gvalue.html
+++ b/docs/gvalue.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/reference-counting.html
+++ b/docs/reference-counting.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/signal-handling.html
+++ b/docs/signal-handling.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/subclassing.html
+++ b/docs/subclassing.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/docs/variadic-functions.html
+++ b/docs/variadic-functions.html
@@ -49,6 +49,9 @@
                 <a href="signal-handling.html">Signal handling</a>
             </li>
             <li>
+                <a href="builder-connect-signals.html">Connecting Builder signals</a>
+            </li>
+            <li>
                 <a href="variadic-functions.html">Variadic functions</a>
             </li>
             <li>

--- a/internal/cmd/docs/main.go
+++ b/internal/cmd/docs/main.go
@@ -25,6 +25,7 @@ var pages = []Page{
 	Page{File: "goroutines", Title: "Goroutines"},
 	Page{File: "casting", Title: "Casting"},
 	Page{File: "signal-handling", Title: "Signal handling"},
+	Page{File: "builder-connect-signals", Title: "Connecting Builder signals"},
 	Page{File: "variadic-functions", Title: "Variadic functions"},
 	Page{File: "gvalue", Title: "gobject.Value"},
 	Page{File: "reference-counting", Title: "Reference counting"},

--- a/internal/docs-src/builder-connect-signals.md
+++ b/internal/docs-src/builder-connect-signals.md
@@ -1,0 +1,66 @@
+## signals in UI definitions
+User interfaces may be defined by in XML documents.
+Such documents are typically edited with Glade.
+
+Signals, along with a named handler, maybe appear in a definition. 
+
+```xml
+<interface>
+  ...
+    <object class="GtkButton" id="ok_button">
+      <signal name="clicked" handler="ok_button_clicked"/>
+    </object>
+  ...
+</interface>
+```
+
+The `handler` attribute value provides a name
+that can be used to associate the signal with a handler function.  
+
+
+## connecting
+To connect signals from a UI definition,
+call `Builder`'s `ConnectSignals` method.
+The single argument is a map of handler names to handler functions
+
+The map keys should match `handler` attribute values in
+the UI definition.
+
+The handler function signatures must match the signal's
+equivalent `Connect...` function.  
+
+## example
+```go
+builder := gtk.BuilderNewFromString(`
+    <interface>
+      <object class="GtkButton" id="ok_button">
+        <signal name="clicked" handler="ok_button_clicked"/>
+        <signal name="draw" handler="draw"/>
+      </object>
+    </interface>
+`)
+
+err := builder.ConnectSignals(map[string]interface{}{
+    "ok_button_clicked": func(button *gtk.Button) {
+        // handle the click
+    },
+    "draw": func(widget *gtk.Widget, cr *cairo.Context) bool {
+        // draw something in the context
+        return false
+    },
+})
+```
+
+See the tests in
+[gtkbuilder-connect-signals_test.go](https://github.com/pekim/gobbi/blob/master/internal/test/gtk/gtkbuilder-connect-signals_test.go)
+for more examples
+including some error scenarios. 
+
+## errors
+There are a number of errors that may occur while connecting signals.
+* A key in the map passed to `ConnectSignals` may not match any
+`handler` attribute value in the UI definition.
+* A handler function's signature may be incorrect.
+* A signal name may be valid, but the signal may not be supported by gobbi.
+
+Any of these will result in an `error` being returned. 

--- a/internal/generate/alias.go
+++ b/internal/generate/alias.go
@@ -19,7 +19,7 @@ type Alias struct {
 
 func (a *Alias) init(ns *Namespace) {
 	a.Namespace = ns
-	//a.goName = makeExportedGoName(a.Name)
+	//a.goName = MakeExportedGoName(a.Name)
 	a.goName = a.Name
 
 	if a.Type != nil {

--- a/internal/generate/constructor.go
+++ b/internal/generate/constructor.go
@@ -17,7 +17,7 @@ func (c *Constructor) init(ns *Namespace, record *Record) {
 	c.ReturnValue.Type.Name = record.Name
 
 	c.Function.init(ns, nil, "")
-	c.GoName = record.GoName + makeExportedGoName(c.Name)
+	c.GoName = record.GoName + MakeExportedGoName(c.Name)
 	c.Function.ctorRecord = record
 
 	if record.Version != "" && c.Version == "" {

--- a/internal/generate/field.go
+++ b/internal/generate/field.go
@@ -20,7 +20,7 @@ type Field struct {
 
 func (f *Field) init(ns *Namespace) {
 	f.Namespace = ns
-	f.goVarName = makeExportedGoName(f.Name)
+	f.goVarName = MakeExportedGoName(f.Name)
 	f.Name = makeSafeCName(f.Name)
 
 	if f.Type != nil {

--- a/internal/generate/function.go
+++ b/internal/generate/function.go
@@ -37,7 +37,7 @@ func (f *Function) init(ns *Namespace, receiver *Record, namePrefix string) {
 	f.Namespace = ns
 	f.receiver = receiver
 	if f.GoName == "" {
-		f.GoName = makeExportedGoName(f.Name)
+		f.GoName = MakeExportedGoName(f.Name)
 	}
 	f.GoName = namePrefix + f.GoName
 	f.Parameters.init(ns)

--- a/internal/generate/goname.go
+++ b/internal/generate/goname.go
@@ -39,7 +39,7 @@ func makeGoName(cName string) string {
 	return name
 }
 
-func makeExportedGoName(cName string) string {
+func MakeExportedGoName(cName string) string {
 	return makeGoNameInternal(cName, true)
 }
 

--- a/internal/generate/namespace-file-generate.go
+++ b/internal/generate/namespace-file-generate.go
@@ -93,6 +93,7 @@ func (ns *Namespace) generateVersionFiles(filename string, version Version,
 		ns.buildConstraintsForVersion(f, version)
 		ns.cgoPreambleHeaders(f, version)
 		ns.generateVersionDebugFunction(f, version.value)
+		ns.generateGobjectClassToGoTypeMetaMap(f, version)
 
 		for _, generatables := range generatablesCollections {
 			for _, entity := range generatables.entities() {

--- a/internal/generate/namespace-gobjectclass-gotype-map.go
+++ b/internal/generate/namespace-gobjectclass-gotype-map.go
@@ -1,0 +1,150 @@
+package generate
+
+import (
+	"fmt"
+	"github.com/dave/jennifer/jen"
+)
+
+type gobjectClassToGoTypeMetaMap struct {
+	ancestorsTypeName string
+	ns                *Namespace
+	file              *jen.File
+	version           *Version
+}
+
+func (ns *Namespace) generateGobjectClassToGoTypeMetaMap(file *jen.File, version Version) {
+	gobjectClassToGoTypeMetaMap{
+		ancestorsTypeName: "classAncestors",
+		ns:                ns,
+		file:              file,
+		version:           &version,
+	}.generate()
+}
+
+func (m gobjectClassToGoTypeMetaMap) generate() {
+	if !m.ns.GenerateGobjectclassGotypeMap {
+		return
+	}
+
+	m.generateClassAncestorsType()
+	m.generateMap()
+	m.file.Line()
+}
+
+func (m gobjectClassToGoTypeMetaMap) generateClassAncestorsType() {
+	m.file.
+		Type().
+		Id(m.ancestorsTypeName).
+		Index().
+		Struct(
+			jen.Id("className").String(),
+			jen.Id("methodName").String(),
+		)
+}
+
+func (m gobjectClassToGoTypeMetaMap) generateMap() {
+	m.file.
+		Var().
+		Id("gobjectClassToGoTypeMetaMap").
+		Op("=").
+		Map(
+			jen.String()).
+		Struct(
+			jen.Id("ctor").Qual("reflect", "Value"),
+			jen.Id("interfaceMethodNames").Index().String(),
+			jen.Id("ancestors").Id(m.ancestorsTypeName)).
+		Values(
+			jen.DictFunc(func(d jen.Dict) {
+				for _, class := range m.ns.Classes {
+					m.generateClass(class, d)
+				}
+			}))
+}
+
+func (m gobjectClassToGoTypeMetaMap) generateClass(class *Class, d jen.Dict) {
+	blacklisted, _ := class.blacklisted()
+	supported, _ := class.supported()
+
+	if blacklisted || !supported || !supportedByVersion(class, m.version) {
+		return
+	}
+
+	d[jen.Lit(class.GlibTypeName)] = jen.Values(jen.Dict{
+		jen.Id("ctor"): jen.
+			Qual("reflect", "ValueOf").
+			Call(jen.Id(class.GoName + "NewFromC")),
+
+		jen.Id("ancestors"): jen.
+			Id(m.ancestorsTypeName).
+			ValuesFunc(func(g *jen.Group) {
+				m.generateClassAncestors(class, g)
+			}),
+
+		jen.Id("interfaceMethodNames"): jen.
+			Index().
+			String().
+			ValuesFunc(func(g *jen.Group) {
+				m.generateInterfaces(class, g)
+			}),
+	})
+}
+
+func (m gobjectClassToGoTypeMetaMap) generateClassAncestors(class *Class, g *jen.Group) {
+	qname := QNameNew(class.Namespace, class.ParentName)
+
+	parent, found := qname.namespace.recordOrClassRecordForName(qname.name)
+	if !found {
+		panic(fmt.Sprintf("Failed to find parent %s for %s", class.ParentName, class.Name))
+	}
+
+	if parent.Blacklist {
+		return
+	}
+
+	previousAncestor := parent
+	ancestorName := previousAncestor.ParentName
+
+	for ancestorName != "" {
+		qname = QNameNew(qname.namespace, ancestorName)
+
+		ancestor, found := qname.namespace.recordOrClassRecordForName(qname.name)
+		if !found {
+			panic(fmt.Sprintf("Failed to find parent %s for %s", ancestorName, previousAncestor.Name))
+		}
+
+		if ancestor.Blacklist {
+			return
+		}
+
+		// Currently the map is only created for the gtk package.
+		// Once an ancestor from a different package is reached, stop.
+		// This is probably okay, as all widgets are descended from a
+		// gobject or atk class.
+		if qname.namespace.goPackageName != m.ns.goPackageName {
+			break
+		}
+
+		g.Values(jen.DictFunc(func(d jen.Dict) {
+			d[jen.Id("className")] = jen.Lit(ancestor.CType)
+			d[jen.Id("methodName")] = jen.Lit(qname.name)
+		}))
+
+		previousAncestor := ancestor
+		ancestorName = previousAncestor.ParentName
+	}
+}
+
+func (m gobjectClassToGoTypeMetaMap) generateInterfaces(class *Class, g *jen.Group) {
+	for _, iface := range class.Implements {
+		if !supportedByVersion(iface, m.version) {
+			return
+		}
+
+		qname := QNameNew(m.ns, iface.Name)
+		if qname.namespace.goPackageName != m.ns.goPackageName {
+			continue
+		}
+
+		g.Lit(qname.name)
+	}
+}

--- a/internal/generate/namespace.go
+++ b/internal/generate/namespace.go
@@ -8,22 +8,23 @@ import (
 )
 
 type Namespace struct {
-	Blacklist           bool         `xml:"blacklist,attr"`
-	Name                string       `xml:"name,attr"`
-	Version             string       `xml:"version,attr"`
-	SharedLibrary       string       `xml:"shared-library,attr"`
-	CDocPath            string       `xml:"c-doc-path,attr"`
-	CIdentifierPrefixes string       `xml:"http://www.gtk.org/introspection/c/1.0 identifier-prefixes,attr"`
-	CSymbolPrefixes     string       `xml:"http://www.gtk.org/introspection/c/1.0 symbol-prefixes,attr"`
-	Aliases             Aliases      `xml:"alias"`
-	Bitfields           Enumerations `xml:"bitfield"`
-	Callbacks           Callbacks    `xml:"callback"`
-	Classes             Classes      `xml:"class"`
-	Constants           Constants    `xml:"constant"`
-	Enumerations        Enumerations `xml:"enumeration"`
-	Functions           Functions    `xml:"function"`
-	Records             Records      `xml:"record"`
-	Interfaces          Interfaces   `xml:"interface"`
+	Blacklist                     bool         `xml:"blacklist,attr"`
+	Name                          string       `xml:"name,attr"`
+	Version                       string       `xml:"version,attr"`
+	SharedLibrary                 string       `xml:"shared-library,attr"`
+	CDocPath                      string       `xml:"c-doc-path,attr"`
+	CIdentifierPrefixes           string       `xml:"http://www.gtk.org/introspection/c/1.0 identifier-prefixes,attr"`
+	CSymbolPrefixes               string       `xml:"http://www.gtk.org/introspection/c/1.0 symbol-prefixes,attr"`
+	Aliases                       Aliases      `xml:"alias"`
+	Bitfields                     Enumerations `xml:"bitfield"`
+	Callbacks                     Callbacks    `xml:"callback"`
+	Classes                       Classes      `xml:"class"`
+	Constants                     Constants    `xml:"constant"`
+	Enumerations                  Enumerations `xml:"enumeration"`
+	Functions                     Functions    `xml:"function"`
+	Records                       Records      `xml:"record"`
+	Interfaces                    Interfaces   `xml:"interface"`
+	GenerateGobjectclassGotypeMap bool         `xml:"generate-gobjectclass-gotype-map,attr"`
 
 	repo              *Repository
 	jenFile           *jen.File
@@ -62,6 +63,7 @@ func (ns *Namespace) init(repo *Repository) {
 func (ns *Namespace) mergeAddenda(addenda *Namespace) {
 	if addenda != nil {
 		ns.Blacklist = addenda.Blacklist
+		ns.GenerateGobjectclassGotypeMap = addenda.GenerateGobjectclassGotypeMap
 
 		if addenda.CDocPath != "" {
 			ns.CDocPath = addenda.CDocPath

--- a/internal/generate/record-cast.go
+++ b/internal/generate/record-cast.go
@@ -35,7 +35,7 @@ func (r *Record) generateUpcasts(g *jen.Group) {
 
 		if _, nameUsedPreviously := methodNames[qname.name]; nameUsedPreviously {
 			// A method for this ancestor would have the same name as an earlier one.
-			// So skip it, and all further ancestors.
+			// So skip it, and all further classAncestors.
 			// This will affect relatively few methods, notably those around Atk.Object.
 			return
 		}

--- a/internal/generate/signal.go
+++ b/internal/generate/signal.go
@@ -56,7 +56,7 @@ func (s *Signal) fixParameterNames() {
 }
 
 func (s *Signal) initNames() {
-	signalGoName := makeExportedGoName(s.Name)
+	signalGoName := MakeExportedGoName(s.Name)
 
 	s.typeStructName = fmt.Sprintf("signal%s%sDetail", s.record.Name, signalGoName)
 	s.varNameId = fmt.Sprintf("signal%s%sId", s.record.Name, signalGoName)

--- a/internal/gir-files/Gtk-3.0-addenda.gir
+++ b/internal/gir-files/Gtk-3.0-addenda.gir
@@ -6,7 +6,7 @@
 >
   <c:include name="../gdk/gdk_event.h"/>
 
-  <namespace>
+  <namespace generate-gobjectclass-gotype-map="true">
     <bitfield name="StyleContextPrintFlags" version="3.20"/>
 
     <constant blacklist="true" name="STOCK_ABOUT"/>
@@ -123,6 +123,10 @@
     <class blacklist="true" name="Plug"/>
     <class blacklist="true" name="Socket"/>
     <class blacklist="true" name="StackAccessible"/>
+
+    <class name="Builder">
+      <method blacklist="true" c:identifier="gtk_builder_connect_signals"/>
+    </class>
 
     <class name="IMContextSimple">
       <method blacklist="true" c:identifier="gtk_im_context_simple_add_compose_file"/>

--- a/internal/test/gtk/gtkbuilder-connect-signals_test.go
+++ b/internal/test/gtk/gtkbuilder-connect-signals_test.go
@@ -1,0 +1,142 @@
+package gtk
+
+import (
+	"github.com/pekim/gobbi/lib/cairo"
+	"github.com/pekim/gobbi/lib/gobject"
+	"github.com/pekim/gobbi/lib/gtk"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestBuildConnectSignals_SignalsOfClass(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkButton" id="ok_button">
+			<signal name="clicked" handler="ok_button_clicked"/>
+			<signal name="enter" handler="ok_button_enter"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"ok_button_clicked": func(_ *gtk.Button) {},
+		"ok_button_enter":   func(_ *gtk.Button) {},
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestBuildConnectSignals_SignalOfAncestor(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkButton" id="ok_button">
+			<signal name="draw" handler="draw"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"draw": func(_ *gtk.Widget, cr *cairo.Context) bool {
+			return false
+		},
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestBuildConnectSignals_SignalOfAncestorInterface(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkSpinButton" id="spin_button">
+			<signal name="changed" handler="spinbutton_changed"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"spinbutton_changed": func(_ *gtk.Editable) {},
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestBuildConnectSignals_BadHandlerName(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkButton" id="ok_button">
+			<signal name="clicked" handler="ok_button_clicked"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"bad_handler_name": func() {},
+	})
+
+	assert.NotNil(t, err)
+}
+
+func TestBuildConnectSignals_BadHandlerSignature(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkButton" id="ok_button">
+			<signal name="clicked" handler="ok_button_clicked"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"ok_button_clicked": func(bad string) {},
+	})
+
+	assert.NotNil(t, err)
+}
+
+func TestBuildConnectSignals_NotifyProperty(t *testing.T) {
+	signalHandled := false
+
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkLabel" id="label">
+			<property name="label">one</property>
+			<signal name="notify::label" handler="label_changed"/>
+		  </object>
+		</interface>
+	`)
+	label := gtk.CastToLabel(builder.GetObject("label"))
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"label_changed": func(_ *gobject.Object, pspec *gobject.ParamSpec) {
+			signalHandled = true
+			assert.Equal(t, label.GetLabel(), "two")
+		},
+	})
+	assert.Nil(t, err)
+
+	label.SetText("two")
+	assert.True(t, signalHandled)
+}
+
+func TestBuildConnectSignals_NotifyPropertyBadHandlerSignature(t *testing.T) {
+	gtk.Init(os.Args)
+	builder := gtk.BuilderNewFromString(`
+		<interface>
+		  <object class="GtkLabel" id="label">
+			<property name="label">one</property>
+			<signal name="notify::label" handler="label_changed"/>
+		  </object>
+		</interface>
+	`)
+
+	err := builder.ConnectSignals(map[string]interface{}{
+		"label_changed": func(bad string) {},
+	})
+	assert.NotNil(t, err)
+}

--- a/lib/gtk/builder-connect-signals.go
+++ b/lib/gtk/builder-connect-signals.go
@@ -1,0 +1,247 @@
+// +build gtk_2.12 gtk_2.14 gtk_2.16 gtk_2.18 gtk_2.20 gtk_2.22 gtk_2.24 gtk_3.10 gtk_3.12 gtk_3.14 gtk_3.16 gtk_3.18 gtk_3.20 gtk_3.22 gtk_3.22.6 gtk_3.22.26 gtk_3.22.29
+
+package gtk
+
+import (
+	"fmt"
+	"github.com/pekim/gobbi/internal/generate"
+	"github.com/pekim/gobbi/lib/gobject"
+	"reflect"
+	"strings"
+	"sync"
+	"unsafe"
+)
+
+/*
+#cgo pkg-config: gtk+-3.0
+#include <gtk/gtk.h>
+
+void gtkBuilderConnectSignal(GObject *object, gchar *class_name, gchar *signal_name, gchar *handler_name, gpointer user_data);
+
+static void Gobbi_gtk_builder_connect(
+	GtkBuilder *builder,
+	GObject *object,
+	const gchar *signal_name,
+	const gchar *handler_name,
+	GObject *connect_object,
+	GConnectFlags flags,
+	gpointer user_data
+) {
+	const gchar *class_name = G_OBJECT_CLASS_NAME(G_OBJECT_GET_CLASS(object));
+	gtkBuilderConnectSignal(object, (gchar *)(class_name), (gchar *)(signal_name), (gchar *)(handler_name), user_data);
+}
+
+static void Gobbi_gtk_builder_connect_signals(GtkBuilder *builder) {
+	gtk_builder_connect_signals_full(
+		builder,
+		Gobbi_gtk_builder_connect,
+		builder
+	);
+}
+*/
+import "C"
+
+type builderConnectSignalsHandlersWrapper struct {
+	handlers map[string]interface{}
+	err      error
+}
+
+func (w *builderConnectSignalsHandlersWrapper) setError(err error) {
+	if w.err == nil {
+		w.err = err
+	}
+}
+
+var builderConnectSignalsHandlers = make(map[unsafe.Pointer]*builderConnectSignalsHandlersWrapper)
+var builderConnectSignalsHandlersLock sync.Mutex
+
+func (b *Builder) ConnectSignals(handlers map[string]interface{}) error {
+	cBuilder := b.ToC()
+	handlersWrapper := &builderConnectSignalsHandlersWrapper{
+		handlers: handlers,
+		err:      nil,
+	}
+
+	// add to map
+	builderConnectSignalsHandlersLock.Lock()
+	builderConnectSignalsHandlers[cBuilder] = handlersWrapper
+	builderConnectSignalsHandlersLock.Unlock()
+
+	// connect signals
+	C.Gobbi_gtk_builder_connect_signals(
+		(*C.GtkBuilder)(cBuilder),
+	)
+
+	// remove from map
+	builderConnectSignalsHandlersLock.Lock()
+	delete(builderConnectSignalsHandlers, cBuilder)
+	builderConnectSignalsHandlersLock.Unlock()
+
+	return handlersWrapper.err
+}
+
+//export gtkBuilderConnectSignal
+func gtkBuilderConnectSignal(
+	cObject *C.GObject,
+	cClassName *C.gchar,
+	cSignalName *C.gchar,
+	cHandlerName *C.gchar,
+	cBuilder C.gpointer, //user data
+) {
+	className := C.GoString(cClassName)
+	signalName := C.GoString(cSignalName)
+	handlerName := C.GoString(cHandlerName)
+
+	handlersWrapper, found := builderConnectSignalsHandlers[unsafe.Pointer(cBuilder)]
+	if !found {
+		panic("builder not found in handlers map")
+	}
+
+	handler, found := handlersWrapper.handlers[handlerName]
+	if !found {
+		handlersWrapper.setError(fmt.Errorf("Handler named '%s' not found", handlerName))
+		return
+	}
+
+	goType, found := gobjectClassToGoTypeMetaMap[className]
+	if !found {
+		handlersWrapper.setError(fmt.Errorf("Class with name '%s' not supported for Builder signal connecting", className))
+		return
+	}
+
+	ctorArgs := []reflect.Value{reflect.ValueOf(unsafe.Pointer(cObject))}
+	ctorReturnValues := goType.ctor.Call(ctorArgs)
+	gtkInstance := ctorReturnValues[0]
+
+	// Connect notify signal.
+	if strings.HasPrefix(signalName, "notify::") {
+		propertyName := strings.TrimPrefix(signalName, "notify::")
+		handlersWrapper.setError(
+			gtkBuilderConnectNotifySignal(gtkInstance, handler, handlerName, propertyName, className))
+		return
+	}
+
+	connectMethod, err := gtkBuilderGetConnectMethodForGoType(
+		gtkInstance,
+		goType.ancestors,
+		goType.interfaceMethodNames,
+		signalName,
+		className,
+	)
+	if err != nil {
+		handlersWrapper.setError(err)
+		return
+	}
+
+	param0Type := connectMethod.Type().In(0)
+	handlerType := reflect.TypeOf(handler)
+	if !handlerType.AssignableTo(param0Type) {
+		handlersWrapper.setError(fmt.Errorf("Signature mistmatch for handler '%s' for signal '%s' of class '%s'",
+			handlerName, signalName, className))
+		return
+	}
+
+	connectArgs := []reflect.Value{reflect.ValueOf(handler)}
+	connectMethod.Call(connectArgs)
+}
+
+func gtkBuilderGetConnectMethodForGoType(
+	gtkInstance reflect.Value,
+	ancestors classAncestors,
+	InterfaceMethodNames []string,
+	signalName string,
+	className string,
+) (reflect.Value, error) {
+	connectMethod, ok := gtkBuilderGetConnectMethod(signalName, gtkInstance, className)
+	if ok {
+		return connectMethod, nil
+	}
+
+	for _, ancestor := range ancestors {
+		ancestorMethod := gtkInstance.MethodByName(ancestor.methodName)
+		if !ancestorMethod.IsValid() {
+			continue
+		}
+
+		ancestorInstance := ancestorMethod.Call(nil)[0]
+
+		connectMethod, ok = gtkBuilderGetConnectMethod(signalName, ancestorInstance, className)
+		if ok {
+			return connectMethod, nil
+		}
+
+		ancestorClass, found := gobjectClassToGoTypeMetaMap[ancestor.className]
+		if !found {
+			return reflect.Value{}, fmt.Errorf("Did not find ancestor class %s for '%s'",
+				ancestor.className, className)
+		}
+
+		connectMethod, ok = gtkBuilderGetConnectMethodForInterfaces(gtkInstance, ancestorClass.interfaceMethodNames, signalName, className)
+		if ok {
+			return connectMethod, nil
+		}
+	}
+
+	connectMethod, ok = gtkBuilderGetConnectMethodForInterfaces(gtkInstance, InterfaceMethodNames, signalName, className)
+	if ok {
+		return connectMethod, nil
+	}
+
+	return reflect.Value{}, fmt.Errorf("Signal '%s' not supported for class '%s' or any of its ancestor classes",
+		signalName, className)
+}
+
+func gtkBuilderGetConnectMethodForInterfaces(
+	gtkInstance reflect.Value,
+	InterfaceMethodNames []string,
+	signalName string,
+	className string,
+) (reflect.Value, bool) {
+	for _, methodName := range InterfaceMethodNames {
+		method := gtkInstance.MethodByName(methodName)
+		if !method.IsValid() {
+			continue
+		}
+
+		interfaceInstance := method.Call(nil)[0]
+
+		connectMethod, ok := gtkBuilderGetConnectMethod(signalName, interfaceInstance, className)
+		if ok {
+			return connectMethod, true
+		}
+	}
+
+	return reflect.Value{}, false
+}
+
+func gtkBuilderGetConnectMethod(signalName string, gtkInstance reflect.Value, className string) (reflect.Value, bool) {
+	connectMethodName := "Connect" + generate.MakeExportedGoName(signalName)
+	connectMethod := gtkInstance.MethodByName(connectMethodName)
+	if !connectMethod.IsValid() {
+		return reflect.Value{}, false
+	}
+
+	return connectMethod, true
+}
+
+func gtkBuilderConnectNotifySignal(
+	gtkInstance reflect.Value,
+	handler interface{},
+	handlerName string,
+	propertyName string,
+	className string,
+) error {
+	expectedHandlerType := reflect.TypeOf(func(*gobject.Object, *gobject.ParamSpec) {})
+	handlerType := reflect.TypeOf(handler)
+	if !handlerType.AssignableTo(expectedHandlerType) {
+		return fmt.Errorf("Signature mistmatch for handler '%s' for property '%s' nofifier  of class '%s'",
+			handlerName, propertyName, className)
+	}
+
+	objectMethod := gtkInstance.MethodByName("Object")
+	objectValue := objectMethod.Call(nil)[0]
+	object := objectValue.Interface().(*gobject.Object)
+	object.ConnectNotifyProperty(propertyName, handler.(func(*gobject.Object, *gobject.ParamSpec)))
+
+	return nil
+}

--- a/lib/gtk/builder-connect-signals.go
+++ b/lib/gtk/builder-connect-signals.go
@@ -55,6 +55,12 @@ func (w *builderConnectSignalsHandlersWrapper) setError(err error) {
 var builderConnectSignalsHandlers = make(map[unsafe.Pointer]*builderConnectSignalsHandlersWrapper)
 var builderConnectSignalsHandlersLock sync.Mutex
 
+// ConnectSignals uses gtk_builder_connect_signals_full to
+// connect signals referenced in a builder definition to signal
+// handler functions.
+//
+// See https://pekim.github.io/gobbi/builder-connect-signals.html
+// for more information.
 func (b *Builder) ConnectSignals(handlers map[string]interface{}) error {
 	cBuilder := b.ToC()
 	handlersWrapper := &builderConnectSignalsHandlersWrapper{

--- a/lib/gtk/v-.go
+++ b/lib/gtk/v-.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2382,6 +2383,2369 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-2.10.go
+++ b/lib/gtk/v-2.10.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2931,6 +2932,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-2.12.go
+++ b/lib/gtk/v-2.12.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3048,6 +3049,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -7835,14 +10204,7 @@ func (recv *Builder) AddFromString(buffer string, length uint64) (uint32, error)
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.14.go
+++ b/lib/gtk/v-2.14.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3084,6 +3085,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8055,14 +10424,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.16.go
+++ b/lib/gtk/v-2.16.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3129,6 +3130,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8275,14 +10644,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.18.go
+++ b/lib/gtk/v-2.18.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3192,6 +3193,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8338,14 +10707,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.2.go
+++ b/lib/gtk/v-2.2.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2436,6 +2437,2369 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-2.20.go
+++ b/lib/gtk/v-2.20.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3210,6 +3211,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8374,14 +10743,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.22.go
+++ b/lib/gtk/v-2.22.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3210,6 +3211,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8406,14 +10775,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.24.go
+++ b/lib/gtk/v-2.24.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3219,6 +3220,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8482,14 +10851,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-2.4.go
+++ b/lib/gtk/v-2.4.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2640,6 +2641,2369 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-2.6.go
+++ b/lib/gtk/v-2.6.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2688,6 +2689,2369 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-2.8.go
+++ b/lib/gtk/v-2.8.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -2697,6 +2698,2369 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle

--- a/lib/gtk/v-3.0.go
+++ b/lib/gtk/v-3.0.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3291,6 +3292,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -8859,14 +11228,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.10.go
+++ b/lib/gtk/v-3.10.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3414,6 +3415,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9524,14 +11893,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.12.go
+++ b/lib/gtk/v-3.12.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3414,6 +3415,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9670,14 +12039,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.14.go
+++ b/lib/gtk/v-3.14.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3621,6 +3622,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9912,14 +12281,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.16.go
+++ b/lib/gtk/v-3.16.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3702,6 +3703,2379 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9993,14 +12367,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.18.go
+++ b/lib/gtk/v-3.18.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3711,6 +3712,2379 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10030,14 +12404,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.2.go
+++ b/lib/gtk/v-3.2.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3318,6 +3319,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9049,14 +11418,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.20.go
+++ b/lib/gtk/v-3.20.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3774,6 +3775,2452 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserNative": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileChooserNativeNewFromC),
+		interfaceMethodNames: []string{"FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNativeDialog": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NativeDialogNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPadController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PadControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkShortcutLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsSection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsSectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsShortcut": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsShortcutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10126,14 +12573,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.22.26.go
+++ b/lib/gtk/v-3.22.26.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3783,6 +3784,2452 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserNative": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileChooserNativeNewFromC),
+		interfaceMethodNames: []string{"FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNativeDialog": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NativeDialogNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPadController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PadControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkShortcutLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsSection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsSectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsShortcut": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsShortcutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10135,14 +12582,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.22.29.go
+++ b/lib/gtk/v-3.22.29.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3801,6 +3802,2452 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserNative": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileChooserNativeNewFromC),
+		interfaceMethodNames: []string{"FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNativeDialog": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NativeDialogNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPadController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PadControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkShortcutLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsSection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsSectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsShortcut": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsShortcutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10153,14 +12600,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.22.6.go
+++ b/lib/gtk/v-3.22.6.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3774,6 +3775,2452 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserNative": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileChooserNativeNewFromC),
+		interfaceMethodNames: []string{"FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNativeDialog": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NativeDialogNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPadController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PadControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkShortcutLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsSection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsSectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsShortcut": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsShortcutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10126,14 +12573,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.22.go
+++ b/lib/gtk/v-3.22.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3774,6 +3775,2452 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserNative": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileChooserNativeNewFromC),
+		interfaceMethodNames: []string{"FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGLArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GLAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNativeDialog": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NativeDialogNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPadController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PadControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkShortcutLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsSection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsSectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsShortcut": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsShortcutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkShortcutsWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ShortcutsWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -10126,14 +12573,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.4.go
+++ b/lib/gtk/v-3.4.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3333,6 +3334,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9291,14 +11660,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.6.go
+++ b/lib/gtk/v-3.6.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3342,6 +3343,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9384,14 +11753,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 

--- a/lib/gtk/v-3.8.go
+++ b/lib/gtk/v-3.8.go
@@ -13,6 +13,7 @@ import (
 	glib "github.com/pekim/gobbi/lib/glib"
 	gobject "github.com/pekim/gobbi/lib/gobject"
 	pango "github.com/pekim/gobbi/lib/pango"
+	"reflect"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -3342,6 +3343,2374 @@ import (
 
 */
 import "C"
+
+type classAncestors []struct {
+	className  string
+	methodName string
+}
+
+var gobjectClassToGoTypeMetaMap = map[string]struct {
+	ctor                 reflect.Value
+	interfaceMethodNames []string
+	ancestors            classAncestors
+}{
+	"GtkAboutDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AboutDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccelLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkMisc",
+			methodName: "Misc",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AccelLabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAccelMap": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccelMapNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ActionBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkActionGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ActionGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAdjustment": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(AdjustmentNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAlignment": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AlignmentNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAppChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserButtonNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkAppChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserDialogNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable"},
+	},
+	"GtkAppChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AppChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"AppChooser", "Buildable", "Orientable"},
+	},
+	"GtkApplication": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ApplicationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkApplicationWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ApplicationWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrow": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ArrowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkArrowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ArrowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkAspectFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AspectFrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkAssistant": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(AssistantNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBin": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BinNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkBooleanCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(BooleanCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(BoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkBuilder": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(BuilderNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkCalendar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CalendarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkCellAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkCellAreaBox": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCellAreaContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellAreaContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRenderer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererAccel": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererAccelNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererCombo": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererComboNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererPixbuf": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererPixbufNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererProgress": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererProgressNewFromC),
+		interfaceMethodNames: []string{"Orientable"},
+	},
+	"GtkCellRendererSpin": {
+		ancestors: classAncestors{{
+			className:  "GtkCellRenderer",
+			methodName: "CellRenderer",
+		}},
+		ctor:                 reflect.ValueOf(CellRendererSpinNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererSpinnerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererText": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererTextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellRendererToggle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellRendererToggleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCellView": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CellViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Orientable"},
+	},
+	"GtkCheckButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkCheckMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(CheckMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkClipboard": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ClipboardNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkColorButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser"},
+	},
+	"GtkColorChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ColorChooser", "Orientable"},
+	},
+	"GtkColorSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkColorSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ColorSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkComboBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkComboBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkComboBoxText": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ComboBoxTextNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "CellLayout"},
+	},
+	"GtkContainer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ContainerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkContainerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkContainerCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ContainerCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkCssProvider": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(CssProviderNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(DialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkDrawingArea": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(DrawingAreaNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEntry": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkEntryAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(EntryAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkEntryCompletion": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EntryCompletionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkEventBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(EventBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkEventController": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(EventControllerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkExpander": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkExpanderAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ExpanderAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFileChooserButton": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser"},
+	},
+	"GtkFileChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FileChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FileChooser", "Orientable"},
+	},
+	"GtkFileFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(FileFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFixed": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FixedNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFlowBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFlowBoxChild": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFlowBoxChildAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FlowBoxChildAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkFontButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "FontChooser"},
+	},
+	"GtkFontChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser"},
+	},
+	"GtkFontChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "FontChooser", "Orientable"},
+	},
+	"GtkFontSelection": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkFontSelectionDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FontSelectionDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrame": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(FrameNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkFrameAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(FrameAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesture": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(GestureNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureDrag": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureDragNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureLongPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureLongPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureMultiPress": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureMultiPressNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGesturePan": {
+		ancestors: classAncestors{{
+			className:  "GtkGestureSingle",
+			methodName: "GestureSingle",
+		}, {
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GesturePanNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureRotate": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureRotateNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSingle": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSingleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureSwipe": {
+		ancestors: classAncestors{{
+			className:  "GtkGesture",
+			methodName: "Gesture",
+		}, {
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureSwipeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGestureZoom": {
+		ancestors: classAncestors{{
+			className:  "GtkEventController",
+			methodName: "EventController",
+		}},
+		ctor:                 reflect.ValueOf(GestureZoomNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkGrid": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(GridNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSV": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(HSVNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkHandleBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HandleBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkHeaderBar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(HeaderBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIMContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMContextSimple": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMContextSimpleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIMMulticontext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IMMulticontextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconFactory": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconFactoryNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkIconInfo": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconInfoNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconTheme": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(IconThemeNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkIconView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(IconViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout", "Scrollable"},
+	},
+	"GtkIconViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(IconViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImage": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkImageAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ImageCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkImageMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ImageMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkInfoBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(InfoBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkInvisible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(InvisibleNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabel": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LabelNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkLabelAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LabelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLayout": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LayoutNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkLevelBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(LevelBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkLevelBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LevelBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkLinkButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLinkButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LinkButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBox": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkListBoxAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListBoxRow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Buildable"},
+	},
+	"GtkListBoxRowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ListBoxRowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkListStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ListStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkLockButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkLockButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(LockButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuShell": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMenuShellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(MenuShellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkMenuToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MenuToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMessageDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(MessageDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkMisc": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MiscNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkModelButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ModelButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkMountOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(MountOperationNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebook": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(NotebookNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkNotebookAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(NotebookAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNotebookPageAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NotebookPageAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkNumerableIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(NumerableIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkOffscreenWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OffscreenWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkOverlay": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(OverlayNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPageSetup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PageSetupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkPanedAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PanedAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPlacesSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PlacesSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopover": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPopoverAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(PopoverAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPopoverMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(PopoverMenuNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkPrintContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkPrintOperation": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintOperationNewFromC),
+		interfaceMethodNames: []string{"PrintOperationPreview"},
+	},
+	"GtkPrintSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(PrintSettingsNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkProgressBar": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ProgressBarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkProgressBarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ProgressBarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioAction": {
+		ancestors: classAncestors{{
+			className:  "GtkAction",
+			methodName: "Action",
+		}},
+		ctor:                 reflect.ValueOf(RadioActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRadioButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToggleButton",
+			methodName: "ToggleButton",
+		}, {
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkButtonAccessible",
+			methodName: "ButtonAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItem",
+			methodName: "MenuItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRadioMenuItemAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuItemAccessible",
+			methodName: "MenuItemAccessible",
+		}, {
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RadioMenuItemAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRadioToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolButton",
+			methodName: "ToolButton",
+		}, {
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RadioToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkRange": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RangeNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkRangeAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RangeAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRcStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RcStyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRecentAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentActionNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserDialog": {
+		ancestors: classAncestors{{
+			className:  "GtkWindow",
+			methodName: "Window",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserDialogNewFromC),
+		interfaceMethodNames: []string{"Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserMenu": {
+		ancestors: classAncestors{{
+			className:  "GtkMenuShell",
+			methodName: "MenuShell",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserMenuNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable", "RecentChooser"},
+	},
+	"GtkRecentChooserWidget": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RecentChooserWidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "RecentChooser"},
+	},
+	"GtkRecentFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentFilterNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkRecentManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(RecentManagerNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRendererCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(RendererCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkRevealer": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(RevealerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScale": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScaleAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScaleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkScaleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScaleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkScrolledWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkScrolledWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ScrolledWindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSearchBar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchBarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSearchEntry": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SearchEntryNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable"},
+	},
+	"GtkSeparator": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkSeparatorMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSeparatorToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SeparatorToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkSettings": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SettingsNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSizeGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SizeGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinButton": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellEditable", "Editable", "Orientable"},
+	},
+	"GtkSpinButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkSpinner": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SpinnerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkSpinnerAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SpinnerAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStack": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSidebar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSidebarNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkStackSwitcher": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StackSwitcherNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusIcon": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StatusIconNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStatusbar": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkStatusbarAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(StatusbarAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyle": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleContext": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StyleContextNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkStyleProperties": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(StylePropertiesNewFromC),
+		interfaceMethodNames: []string{"StyleProvider"},
+	},
+	"GtkSwitch": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(SwitchNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkSwitchAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(SwitchAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTable": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTearoffMenuItem": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TearoffMenuItemNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkTextBuffer": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextBufferNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextCellAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkCellAccessible",
+			methodName: "CellAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextCellAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextChildAnchor": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextChildAnchorNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextMark": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextMarkNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTag": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTextTagTable": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TextTagTableNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkTextView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TextViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTextViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TextViewAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkThemingEngine": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ThemingEngineNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleAction": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToggleActionNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkToggleButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToggleButtonAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkContainerAccessible",
+			methodName: "ContainerAccessible",
+		}, {
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(ToggleButtonAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToggleToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkToolItem",
+			methodName: "ToolItem",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToggleToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolButton": {
+		ancestors: classAncestors{{
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable"},
+	},
+	"GtkToolItem": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemNewFromC),
+		interfaceMethodNames: []string{"Activatable", "Buildable"},
+	},
+	"GtkToolItemGroup": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolItemGroupNewFromC),
+		interfaceMethodNames: []string{"Buildable", "ToolShell"},
+	},
+	"GtkToolPalette": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolPaletteNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "Scrollable"},
+	},
+	"GtkToolbar": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ToolbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable", "ToolShell"},
+	},
+	"GtkTooltip": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TooltipNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkToplevelAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(ToplevelAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeModelFilter": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelFilterNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel"},
+	},
+	"GtkTreeModelSort": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeModelSortNewFromC),
+		interfaceMethodNames: []string{"TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeSelection": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeSelectionNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkTreeStore": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeStoreNewFromC),
+		interfaceMethodNames: []string{"Buildable", "TreeDragDest", "TreeDragSource", "TreeModel", "TreeSortable"},
+	},
+	"GtkTreeView": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkTreeViewAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(TreeViewAccessibleNewFromC),
+		interfaceMethodNames: []string{"CellAccessibleParent"},
+	},
+	"GtkTreeViewColumn": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(TreeViewColumnNewFromC),
+		interfaceMethodNames: []string{"Buildable", "CellLayout"},
+	},
+	"GtkUIManager": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(UIManagerNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkVBox": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVButtonBox": {
+		ancestors: classAncestors{{
+			className:  "GtkBox",
+			methodName: "Box",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VButtonBoxNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVPaned": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VPanedNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScale": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScaleNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVScrollbar": {
+		ancestors: classAncestors{{
+			className:  "GtkRange",
+			methodName: "Range",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VScrollbarNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkVSeparator": {
+		ancestors: classAncestors{{
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VSeparatorNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Orientable"},
+	},
+	"GtkViewport": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(ViewportNewFromC),
+		interfaceMethodNames: []string{"Buildable", "Scrollable"},
+	},
+	"GtkVolumeButton": {
+		ancestors: classAncestors{{
+			className:  "GtkButton",
+			methodName: "Button",
+		}, {
+			className:  "GtkBin",
+			methodName: "Bin",
+		}, {
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(VolumeButtonNewFromC),
+		interfaceMethodNames: []string{"Actionable", "Activatable", "Buildable", "Orientable"},
+	},
+	"GtkWidget": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWidgetAccessible": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WidgetAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindow": {
+		ancestors: classAncestors{{
+			className:  "GtkContainer",
+			methodName: "Container",
+		}, {
+			className:  "GtkWidget",
+			methodName: "Widget",
+		}},
+		ctor:                 reflect.ValueOf(WindowNewFromC),
+		interfaceMethodNames: []string{"Buildable"},
+	},
+	"GtkWindowAccessible": {
+		ancestors: classAncestors{{
+			className:  "GtkWidgetAccessible",
+			methodName: "WidgetAccessible",
+		}, {
+			className:  "GtkAccessible",
+			methodName: "Accessible",
+		}},
+		ctor:                 reflect.ValueOf(WindowAccessibleNewFromC),
+		interfaceMethodNames: []string{},
+	},
+	"GtkWindowGroup": {
+		ancestors:            classAncestors{},
+		ctor:                 reflect.ValueOf(WindowGroupNewFromC),
+		interfaceMethodNames: []string{},
+	},
+}
 
 // Allocation is a representation of the C alias GtkAllocation.
 type Allocation *gdk.Rectangle
@@ -9384,14 +11753,7 @@ func (recv *Builder) AddObjectsFromString(buffer string, length uint64, objectId
 	return retGo, goError
 }
 
-// ConnectSignals is a wrapper around the C function gtk_builder_connect_signals.
-func (recv *Builder) ConnectSignals(userData uintptr) {
-	c_user_data := (C.gpointer)(userData)
-
-	C.gtk_builder_connect_signals((*C.GtkBuilder)(recv.native), c_user_data)
-
-	return
-}
+// Blacklisted : gtk_builder_connect_signals
 
 // Unsupported : gtk_builder_connect_signals_full : unsupported parameter func : no type generator for BuilderConnectFunc (GtkBuilderConnectFunc) for param func
 


### PR DESCRIPTION
Add a new `ConnectSignals` method for `gtk.Builder`.
This addresses #10.

Documentation can be previewed at
https://github.com/pekim/gobbi/blob/builder-connect-signals-2/internal/docs-src/builder-connect-signals.md.